### PR TITLE
Update copyright year in license

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 WooCommerce - eCommerce for WordPress
 
-Copyright 2015 by the contributors
+Copyright 2026 by the contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Refreshes the copyright year in license.txt from 2015 to 2026 so the project metadata matches the current year.