### PR TITLE
Downgrade Algolia PHP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
-    "name": "daniel/algolia-woo-indexer",
-    "type": "wordpress-plugin",
-    "authors": [
-        {
-            "name": "w3bdesign",
-            "email": "45217974+w3bd3sign@users.noreply.github.com"
-        }
-    ],
-    "require": {
-        "algolia/algoliasearch-client-php": "^4.38"
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpcompatibility/phpcs-compatinfo": true
-        }
-    },
-    "require-dev": {
-        "squizlabs/php_codesniffer": "*",
-        "wp-coding-standards/wpcs": "*",
-        "phpcompatibility/phpcompatibility-wp": "*"
+  "name": "daniel/algolia-woo-indexer",
+  "type": "wordpress-plugin",
+  "authors": [
+    {
+      "name": "w3bdesign",
+      "email": "45217974+w3bd3sign@users.noreply.github.com"
     }
+  ],
+  "require": {
+    "algolia/algoliasearch-client-php": "^2.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpcompatibility/phpcs-compatinfo": true
+    }
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "*",
+    "wp-coding-standards/wpcs": "*",
+    "phpcompatibility/phpcompatibility-wp": "*"
+  }
 }


### PR DESCRIPTION
This change lowers the Algolia PHP client dependency from v4 to v2.6 and normalizes the Composer manifest formatting. The update keeps the plugin aligned with the dependency version expected by the project and avoids compatibility issues in the current environment.